### PR TITLE
relax cython version requirement

### DIFF
--- a/.github/workflows/end_to_end_pytest.yml
+++ b/.github/workflows/end_to_end_pytest.yml
@@ -29,7 +29,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y hdf5-tools libhdf5-openmpi-dev openmpi-bin
           python -m pip install --upgrade pip
-          python -m pip install --upgrade pytest mpi4py "cython<3.0.0" numpy wheel pkgconfig setuptools
+          python -m pip install --upgrade pytest mpi4py cython numpy wheel pkgconfig setuptools
           # we need to build h5py with the system HDF5 lib backend
           export HDF5_MPI="ON"
           # Install h5py https://github.com/h5py/h5py/issues/2222


### PR DESCRIPTION
Otherwise, Github CI build failed when building h5py Building wheels for collected packages: h5py
  Building wheel for h5py (pyproject.toml): started
  Building wheel for h5py (pyproject.toml): finished with status 'error'
  error: subprocess-exited-with-error

  × Building wheel for h5py (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [184 lines of output]
  ...
  Error compiling Cython file:
  ------------------------------------------------------------
  ...
      if filter_idx < 0:
          raise ValueError("Filter index must be a non-negative integer")

      filter_code = <int>H5Pget_filter(self.id, filter_idx, &flags,
                                       &nelements, cd_values, 256, name, NULL)
      assert nelements <= 256, f"H5Pget_filter returned {nelements=}"
                                                                    ^
  ------------------------------------------------------------

      h5py/h5p.pyx:714:71: Expected ')', found '='
      Loading library to get build settings and version: /usr/lib/x86_64-linux-gnu/hdf5/openmpi/libhdf5.so