### PR TITLE
fix release 3.5.0 - to use patched darshan-apmpi.c

### DIFF
--- a/darshan-runtime/configure.ac
+++ b/darshan-runtime/configure.ac
@@ -314,19 +314,31 @@ if test "x$enable_darshan_runtime" = xyes ; then
       )
 
       AC_MSG_CHECKING([whether patching darshan-apmpi.c is necessary])
-      submod_status="m4_esyscmd_s([git submodule status])"
-      apmpi_mod_sha=`echo ${submod_status} | cut -d' ' -f1`
+      # check if command git is available.
+      is_srcdir_git_clone=
+      AC_CHECK_PROG(GIT_CMD, git, git)
+      if test "x$GIT_CMD" != x ; then
+         # Check if folder ${srcdir} is in a git repository clone
+         is_srcdir_git_clone=`git -C ${srcdir} rev-parse --is-inside-work-tree 2>/dev/null`
+      fi
+      apply_apmpi_patch=no
+      if test "x${is_srcdir_git_clone}" = xtrue ; then
+         submod_status=`git submodule status`
+         apmpi_mod_sha=`echo ${submod_status} | cut -d' ' -f1`
 
-      if test "x$apmpi_mod_sha" = x8623a0652735785fe87d89514112e43e4f52a78d ; then
-         apply_apmpi_patch=yes
-      else
-         # check if git HAED of autoperf is a descendent of 8623a06
-         ac_flag=m4_esyscmd_s([cd ../modules/autoperf && git merge-base --is-ancestor 8623a0652735785fe87d89514112e43e4f52a78d HEAD && echo "$?"])
-         if test "x$ac_flag" = x0 ; then
-            apply_apmpi_patch=no
-         else
+         if test "x$apmpi_mod_sha" = x8623a0652735785fe87d89514112e43e4f52a78d ; then
             apply_apmpi_patch=yes
+         else
+            # check if git HAED of autoperf is a descendent of 8623a06
+            ac_flag=`cd ../modules/autoperf && git merge-base --is-ancestor 8623a0652735785fe87d89514112e43e4f52a78d HEAD && echo "$?"`
+            if test "x$ac_flag" = x0 ; then
+               apply_apmpi_patch=no
+            else
+               apply_apmpi_patch=yes
+            fi
          fi
+      elif test "x${PACKAGE_VERSION}" = "x3.5.0" ; then
+         apply_apmpi_patch=yes
       fi
       AC_MSG_RESULT([$apply_apmpi_patch])
    fi

--- a/darshan-runtime/lib/Makefile.am
+++ b/darshan-runtime/lib/Makefile.am
@@ -81,26 +81,29 @@ endif
 
 CLEANFILES = darshan-pnetcdf-api.c
 
+nodist_libdarshan_la_SOURCES =
+nodist_libdarshan_a_SOURCES =
+
 include_HEADERS =
 apxc_root = $(top_srcdir)/../modules/autoperf/apxc
 if BUILD_APXC_MODULE
    include_HEADERS += $(apxc_root)/darshan-apxc-log-format.h \
                       $(apxc_root)/lib/darshan-apxc-utils.h
-   BUILT_SOURCES += darshan-apxc.c
    CLEANFILES += darshan-apxc.c
-   C_SRCS += darshan-apxc.c
+   nodist_libdarshan_la_SOURCES += darshan-apxc.c
+   nodist_libdarshan_a_SOURCES += darshan-apxc.c
    AM_CPPFLAGS += -DDARSHAN_USE_APXC \
                   -I$(apxc_root) -I$(apxc_root)/lib
 endif
 darshan-apxc.c:
-	$(LN_S) $(apxc_root)/lib/darshan-apxc.c .
+	$(LN_S) $(apxc_root)/lib/darshan-apxc.c $@
 
 apmpi_root = $(top_srcdir)/../modules/autoperf/apmpi
 if BUILD_APMPI_MODULE
    include_HEADERS += $(apmpi_root)/darshan-apmpi-log-format.h
-   BUILT_SOURCES += darshan-apmpi.c
    CLEANFILES += darshan-apmpi.c
-   C_SRCS += darshan-apmpi.c
+   nodist_libdarshan_la_SOURCES += darshan-apmpi.c
+   nodist_libdarshan_a_SOURCES += darshan-apmpi.c
    AM_CPPFLAGS += -DDARSHAN_USE_APMPI \
                   -I$(apmpi_root) -I$(apmpi_root)/lib
 endif


### PR DESCRIPTION
The 3.5.0 release tarball does not automatically use the patched darshan-apmpi.c.
This PR checks if Darshan is being built using either that release tarball or a
git clone, so to determine whether the patch file should be used.